### PR TITLE
Small improvements

### DIFF
--- a/jinja.py
+++ b/jinja.py
@@ -3,6 +3,7 @@
 
 import os
 import codecs
+import fnmatch
 from jinja2 import Environment, FileSystemLoader, Template
 from difflib import unified_diff
 from datetime import datetime
@@ -36,6 +37,8 @@ class template:
             if not os.path.isdir(fileout):
                 os.makedirs(fileout)
             for file in os.listdir(filein):
+                if fnmatch.fnmatch(file, '*~'): continue
+                if fnmatch.fnmatch(file, '.*.sw?'): continue
                 next_fileout = fileout + '/' + file
                 next_filein  = filein + '/'  + file
                 self.save(next_filein, next_fileout, mode, diff)

--- a/sources/index.html
+++ b/sources/index.html
@@ -24,7 +24,9 @@ converter.setOption('parseImgDimensions', true);
 
 var pages = {}
 {% for page in navigation %}
+{% if page.file %}
 pages['{{page.file}}']= '{{page.title}}';
+{% endif %}
 {% endfor %}
 
 
@@ -114,7 +116,11 @@ $(document).ready(function(){
                     <div id="menu-box">
 <ul>
     {% for entry in navigation|sort(attribute='order') %}
+    {% if entry.file %}
     <li class="li_level_1_not_selected" id="li_{{entry.file}}"><a class="level_1_not_selected" href="#{{entry.file}}">{{entry.title}}</a></li>
+    {% elif entry.href %}
+    <li class="li_level_1_not_selected" id="li_{{entry.title}}"><a class="level_1_not_selected" href="{{entry.href}}">{{entry.title}}</a></li>
+    {% endif %}
     {% endfor %}
 </ul><br/> 
 </div>

--- a/sources/index.html
+++ b/sources/index.html
@@ -54,7 +54,9 @@ function openPage(file) {
             if(pages.hasOwnProperty(file)) {
                 resetNavigation();
                 setNavigation('#li_' + file);
-                document.title = pages[file];
+                document.title = '{{startpage.title}}'+' - '+pages[file];
+            } else {
+                document.title = '{{startpage.title}}';
             }
 
             $(".markdown").each(function() {


### PR DESCRIPTION
* Ignore temporary files  
  When editing with vi, the publish script complained about not understanding the .swp file, as it is binary.
  Ignores both vi-style `.*.sw?` and emacs-style `*~` files
* Allow links in left navigation bar
  Let's you put links there with the same syntax as used in the links on the top.
* Prefix title with global title
  Puts the global title before the page title and separates the two with a dash. I believe this gives a more useful entry, e.g. for lectures `Moderne Theoretische Physik II - Exercises` instead of having only `Exercises`.